### PR TITLE
Add Support for Error Messages in Drill 1.19

### DIFF
--- a/src/DrillConnection.php
+++ b/src/DrillConnection.php
@@ -147,8 +147,8 @@ class DrillConnection {
 		$response = $this->post_request($url, $postData);
 
 		if (isset($response['errorMessage'])) {
-			$this->errorMessage = $response['errorMessage'];
-			$this->stackTrace = $response['stackTrace'] ?? '';
+			$this->error_message = $response['errorMessage'];
+			$this->stack_trace = $response['stackTrace'] ?? '';
 			throw new \Exception("Error in query: {$query}");
 		} else {
 			return new Result($response, $query);

--- a/src/DrillConnection.php
+++ b/src/DrillConnection.php
@@ -147,7 +147,8 @@ class DrillConnection {
 		$response = $this->post_request($url, $postData);
 
 		if (isset($response['errorMessage'])) {
-			$this->error_message = $response['errorMessage'];
+			$this->errorMessage = $response['errorMessage'];
+			$this->stackTrace = $response['stackTrace'] ?? '';
 			throw new \Exception("Error in query: {$query}");
 		} else {
 			return new Result($response, $query);

--- a/src/DrillConnection.php
+++ b/src/DrillConnection.php
@@ -137,7 +137,10 @@ class DrillConnection {
 		$postData = array(
 			'queryType' => 'SQL',
 			'query' => $query,
-			'autoLimit' => $this->row_limit
+			'autoLimit' => $this->row_limit,
+      'options' => array(
+        'drill.exec.http.rest.errors.verbose' => true
+      )
 		);
 
 		$response = $this->post_request($url, $postData);

--- a/src/DrillConnection.php
+++ b/src/DrillConnection.php
@@ -129,6 +129,7 @@ class DrillConnection {
 	 * @param string $query The query to run/execute
 	 *
 	 * @return ?Result Returns Result object if the query executed successfully, null otherwise.
+	 * @throws \Exception
 	 */
 	function query(string $query): ?Result {
 
@@ -138,18 +139,18 @@ class DrillConnection {
 			'queryType' => 'SQL',
 			'query' => $query,
 			'autoLimit' => $this->row_limit,
-      'options' => array(
-        'drill.exec.http.rest.errors.verbose' => true
-      )
+			'options' => [
+				'drill.exec.http.rest.errors.verbose' => true
+			]
 		);
 
 		$response = $this->post_request($url, $postData);
 
 		if (isset($response['errorMessage'])) {
 			$this->error_message = $response['errorMessage'];
-			return null;
+			throw new \Exception("Error in query: {$query}");
 		} else {
-			return new namespace\Result($response, $query);
+			return new Result($response, $query);
 		}
 
 	}

--- a/test/DrillTest.php
+++ b/test/DrillTest.php
@@ -23,7 +23,6 @@ class DrillTest extends TestCase {
 		$this->drill = new DrillConnection($this->host, $this->port, $this->username, $this->password, $this->ssl, $this->row_limit);
 		$active = $this->drill->is_active();
 		$this->assertEquals(true, $active);
-
 	}
 
 	public function testBadConnection() {
@@ -48,6 +47,14 @@ class DrillTest extends TestCase {
 		$enabledPlugins = $d->get_enabled_storage_plugins();
 		$this->assertEquals(6, count($enabledPlugins));
 	}
+
+	public function testErrorMessage() {
+    $this->drill = new DrillConnection($this->host, $this->port, $this->username, $this->password, $this->ssl, $this->row_limit);
+    $result = $this->drill->query("SELECT CAST('abc' AS INT) FROM (VALUES(1))");
+    $this->assertNotEmpty($this->drill->error_message());
+    $this->assertStringStartsWith("Unexpected exception during fragment initialization",
+      $this->drill->error_message());
+  }
 
 	public function testFormatTable() {
 		$d = new DrillConnection($this->host, $this->port, $this->username, $this->password, $this->ssl, $this->row_limit);


### PR DESCRIPTION
Drill 1.19 introduced a new streaming REST API which also introduced changes into how Drill handles error messages.  As a result, in DDR, when the user submits a query to Drill via DDR, they were not getting a meaningful error message. 
This minor PR fixes this issue by passing Drill an additional option at query time:

```json
options {
       "drill.exec.http.rest.errors.verbose":  true
      }
```

When this option is set to `true`, Drill will return all error reporting, to include the full stack trace in the event of an error.   The error message can be retrieved in the `error_message()` function of the `Result` class.   

